### PR TITLE
Fixed parsing of integers

### DIFF
--- a/AddmusicK/MML/Lexers/Core.cpp
+++ b/AddmusicK/MML/Lexers/Core.cpp
@@ -16,31 +16,38 @@ LEXER_FUNC_START(Lexer::Int)
 //	if (file.Trim("\\$"))
 //		return Hex2()(file);
 	if (auto x = file.Trim("[[:digit:]]+")) {
-		auto ret = static_cast<arg_type>(std::strtoul(x->data(), nullptr, 10));
-		if (errno != ERANGE)
-			return ret;
+		arg_type value;
+		if (std::from_chars(x->data(), x->data() + x->size(), value, 10).ec == std::errc{}) {
+			return value;
+		}
 	}
 LEXER_FUNC_END()
 
 LEXER_FUNC_START(Lexer::HexInt)
 	if (auto x = file.Trim("[[:xdigit:]]+")) {
-		auto ret = static_cast<arg_type>(std::strtoul(x->data(), nullptr, 16));
-		if (errno != ERANGE)
-			return ret;
+		arg_type value;
+		if (std::from_chars(x->data(), x->data() + x->size(), value, 16).ec == std::errc{}) {
+			return value;
+		}
 	}
 LEXER_FUNC_END()
 
 LEXER_FUNC_START(Lexer::SInt)
 	if (auto x = file.Trim("[+-]?[[:digit:]]+")) {
-		auto ret = static_cast<arg_type>(std::strtol(x->data(), nullptr, 10));
-		if (errno != ERANGE)
-			return ret;
+		arg_type value;
+		if (std::from_chars(x->data(), x->data() + x->size(), value, 10).ec == std::errc{}) {
+			return value;
+		}
 	}
 LEXER_FUNC_END()
 
 LEXER_FUNC_START(Lexer::Byte)
-	if (auto x = file.Trim("\\$[[:xdigit:]]{2}"))
-		return static_cast<arg_type>(std::strtoul(x->data() + 1, nullptr, 16));
+	if (auto x = file.Trim("\\$[[:xdigit:]]{2}")) {
+		arg_type value;
+		if (std::from_chars(x->data() + 1, x->data() + x->size(), value, 16).ec == std::errc{}) {
+			return value;
+		}
+	}
 LEXER_FUNC_END()
 
 LEXER_FUNC_START(Lexer::Ident)
@@ -74,9 +81,11 @@ LEXER_FUNC_START(Lexer::Time)
 	if (auto x = file.Trim("[[:digit:]]{1,2}"))
 		if (file.Trim(':'))
 			if (auto y = file.Trim("[[:digit:]]{2}")) {
-				auto m = static_cast<arg_type>(std::strtoul(x->data(), nullptr, 10));
-				auto s = static_cast<arg_type>(std::strtoul(y->data(), nullptr, 10));
-				return m * 60 + s;
+				arg_type m, s;
+				if (std::from_chars(x->data(), x->data() + x->size(), m, 10).ec == std::errc{} &&
+				    std::from_chars(y->data(), y->data() + y->size(), s, 10).ec == std::errc{} ) {
+					return m * 60 + s;
+				}
 			}
 LEXER_FUNC_END()
 

--- a/AddmusicK/MML/Lexers/Core.h
+++ b/AddmusicK/MML/Lexers/Core.h
@@ -5,6 +5,7 @@
 #include <utility>
 #include <initializer_list>
 #include <cstdlib>
+#include <charconv>
 #include "../SourceView.h"
 #include "../Duration.h"
 #include "../Accidental.h"
@@ -232,8 +233,12 @@ struct Hex
 	}; // "[[:xdigit:]]{N}"
 	using arg_type = unsigned;
 	std::optional<arg_type> operator()(SourceView &file) {
-		if (auto x = file.Trim(fmt))
-			return static_cast<arg_type>(std::strtol(x->data(), nullptr, 16));
+		if (auto x = file.Trim(fmt)) {
+			arg_type value;
+			if (std::from_chars(x->data(), x->data() + x->size(), value, 16).ec == std::errc{}) {
+				return value;
+			}
+		}
 		return std::nullopt;
 	}
 };


### PR DESCRIPTION
string_view::data() must not be interpreted as a C-string (ie *not*
passed to strtol etc.), because it may not be terminated
properly. Example:

    string_view{"asd"}.substr(0,2).data()

is "asd", *not* "as".

This is an issue when fixed length literals are not separated in the
MML - for example
in (https://www.smwcentral.net/?p=section&a=details&id=18255),
"q7Ad16" was tokenized correctly as "q", "7A" - but then the
conversion to int returned 0x7ad16 instead of 0x7a.