### PR TITLE
Minor documentation fix.

### DIFF
--- a/doc/readme_files/hex_command_reference.html
+++ b/doc/readme_files/hex_command_reference.html
@@ -965,7 +965,7 @@
 			<td>16<sup>th</sup> note<br /></td>
 		</tr>
 		<tr>
-			<td>$09<br /></td>
+			<td>$08<br /></td>
 			<td>16<sup>th</sup> triplet <br /></td>
 		</tr>
 		<tr>


### PR DESCRIPTION
This is an obvious typo.  All of the other hex values are even numbers, and $08 makes a lot more sense in relation to the other values.